### PR TITLE
Physical lights cases update

### DIFF
--- a/jobs/Tests/Physical_Lights/test_cases.json
+++ b/jobs/Tests/Physical_Lights/test_cases.json
@@ -654,13 +654,13 @@
         "case": "BL28_L_PL_043",
         "status": "active",
         "script_info": [
-            "Sun light, int = 100, Shadow Softness - 0.00"
+            "Sun light, int = 1000, Shadow Softness Angle - 0.00"
         ],
         "scene": "Physical_Lights.blend",
         "functions": [
             "light_data = getLightWithType('SUN')",
-            "set_value(light_data, 'energy', 100)",
-            "set_value(light_data.rpr, 'shadow_softness', 0)",
+            "set_value(light_data, 'energy', 1000)",
+            "set_value(light_data.rpr, 'shadow_softness_angle', 0)",
             "rpr_render(case)",
             "bpy.ops.wm.open_mainfile(filepath=os.path.join(RES_PATH, 'Physical_Lights.blend'))"
         ]
@@ -669,13 +669,13 @@
         "case": "BL28_L_PL_044",
         "status": "active",
         "script_info": [
-            "Sun light, int = 100, Shadow Softness - 0.1"
+            "Sun light, int = 1000, Shadow Softness Angle - 1"
         ],
         "scene": "Physical_Lights.blend",
         "functions": [
             "light_data = getLightWithType('SUN')",
-            "set_value(light_data, 'energy', 100)",
-            "set_value(light_data.rpr, 'shadow_softness', 1)",
+            "set_value(light_data, 'energy', 1000)",
+            "set_value(light_data.rpr, 'shadow_softness_angle', 1)",
             "rpr_render(case)",
             "bpy.ops.wm.open_mainfile(filepath=os.path.join(RES_PATH, 'Physical_Lights.blend'))"
         ]
@@ -684,13 +684,13 @@
         "case": "BL28_L_PL_045",
         "status": "active",
         "script_info": [
-            "Sun light, int = 100, Shadow Softness - 0.5"
+            "Sun light, int = 1000, Shadow Softness Angle - 20"
         ],
         "scene": "Physical_Lights.blend",
         "functions": [
             "light_data = getLightWithType('SUN')",
-            "set_value(light_data, 'energy', 100)",
-            "set_value(light_data.rpr, 'shadow_softness', 20)",
+            "set_value(light_data, 'energy', 1000)",
+            "set_value(light_data.rpr, 'shadow_softness_angle', 20)",
             "rpr_render(case)",
             "bpy.ops.wm.open_mainfile(filepath=os.path.join(RES_PATH, 'Physical_Lights.blend'))"
         ]
@@ -699,13 +699,13 @@
         "case": "BL28_L_PL_046",
         "status": "active",
         "script_info": [
-            "Sun light, int = 100, Shadow Softness - 1"
+            "Sun light, int = 1000, Shadow Softness Angle - 90"
         ],
         "scene": "Physical_Lights.blend",
         "functions": [
             "light_data = getLightWithType('SUN')",
-            "set_value(light_data, 'energy', 100)",
-            "set_value(light_data.rpr, 'shadow_softness', 90)",
+            "set_value(light_data, 'energy', 1000)",
+            "set_value(light_data.rpr, 'shadow_softness_angle', 90)",
             "rpr_render(case)",
             "bpy.ops.wm.open_mainfile(filepath=os.path.join(RES_PATH, 'Physical_Lights.blend'))"
         ]

--- a/jobs/Tests/Physical_Lights/test_cases.json
+++ b/jobs/Tests/Physical_Lights/test_cases.json
@@ -675,7 +675,7 @@
         "functions": [
             "light_data = getLightWithType('SUN')",
             "set_value(light_data, 'energy', 1000)",
-            "set_value(light_data.rpr, 'shadow_softness_angle', 1)",
+            "set_value(light_data.rpr, 'shadow_softness_angle', 1/57.3)",
             "rpr_render(case)",
             "bpy.ops.wm.open_mainfile(filepath=os.path.join(RES_PATH, 'Physical_Lights.blend'))"
         ]
@@ -690,7 +690,7 @@
         "functions": [
             "light_data = getLightWithType('SUN')",
             "set_value(light_data, 'energy', 1000)",
-            "set_value(light_data.rpr, 'shadow_softness_angle', 20)",
+            "set_value(light_data.rpr, 'shadow_softness_angle', 20/57.3)",
             "rpr_render(case)",
             "bpy.ops.wm.open_mainfile(filepath=os.path.join(RES_PATH, 'Physical_Lights.blend'))"
         ]
@@ -705,7 +705,7 @@
         "functions": [
             "light_data = getLightWithType('SUN')",
             "set_value(light_data, 'energy', 1000)",
-            "set_value(light_data.rpr, 'shadow_softness_angle', 90)",
+            "set_value(light_data.rpr, 'shadow_softness_angle', 90/57.3)",
             "rpr_render(case)",
             "bpy.ops.wm.open_mainfile(filepath=os.path.join(RES_PATH, 'Physical_Lights.blend'))"
         ]

--- a/jobs/Tests/Physical_Lights/test_cases.json
+++ b/jobs/Tests/Physical_Lights/test_cases.json
@@ -654,12 +654,12 @@
         "case": "BL28_L_PL_043",
         "status": "active",
         "script_info": [
-            "Sun light, int = 1000, Shadow Softness Angle - 0.00"
+            "Sun light, int = 300, Shadow Softness Angle - 0.00"
         ],
         "scene": "Physical_Lights.blend",
         "functions": [
             "light_data = getLightWithType('SUN')",
-            "set_value(light_data, 'energy', 1000)",
+            "set_value(light_data, 'energy', 300)",
             "set_value(light_data.rpr, 'shadow_softness_angle', 0)",
             "rpr_render(case)",
             "bpy.ops.wm.open_mainfile(filepath=os.path.join(RES_PATH, 'Physical_Lights.blend'))"
@@ -669,12 +669,12 @@
         "case": "BL28_L_PL_044",
         "status": "active",
         "script_info": [
-            "Sun light, int = 1000, Shadow Softness Angle - 1"
+            "Sun light, int = 300, Shadow Softness Angle - 1"
         ],
         "scene": "Physical_Lights.blend",
         "functions": [
             "light_data = getLightWithType('SUN')",
-            "set_value(light_data, 'energy', 1000)",
+            "set_value(light_data, 'energy', 300)",
             "set_value(light_data.rpr, 'shadow_softness_angle', 1/57.3)",
             "rpr_render(case)",
             "bpy.ops.wm.open_mainfile(filepath=os.path.join(RES_PATH, 'Physical_Lights.blend'))"
@@ -684,12 +684,12 @@
         "case": "BL28_L_PL_045",
         "status": "active",
         "script_info": [
-            "Sun light, int = 1000, Shadow Softness Angle - 20"
+            "Sun light, int = 300, Shadow Softness Angle - 20"
         ],
         "scene": "Physical_Lights.blend",
         "functions": [
             "light_data = getLightWithType('SUN')",
-            "set_value(light_data, 'energy', 1000)",
+            "set_value(light_data, 'energy', 300)",
             "set_value(light_data.rpr, 'shadow_softness_angle', 20/57.3)",
             "rpr_render(case)",
             "bpy.ops.wm.open_mainfile(filepath=os.path.join(RES_PATH, 'Physical_Lights.blend'))"
@@ -699,12 +699,12 @@
         "case": "BL28_L_PL_046",
         "status": "active",
         "script_info": [
-            "Sun light, int = 1000, Shadow Softness Angle - 90"
+            "Sun light, int = 300, Shadow Softness Angle - 90"
         ],
         "scene": "Physical_Lights.blend",
         "functions": [
             "light_data = getLightWithType('SUN')",
-            "set_value(light_data, 'energy', 1000)",
+            "set_value(light_data, 'energy', 300)",
             "set_value(light_data.rpr, 'shadow_softness_angle', 90/57.3)",
             "rpr_render(case)",
             "bpy.ops.wm.open_mainfile(filepath=os.path.join(RES_PATH, 'Physical_Lights.blend'))"


### PR DESCRIPTION
Параметр Shadow Softness был удален, соответствующие тест кейсы были переработаны. Этот ПР  обновляет кейсы в группе Physical_Lights 043-046
https://rpr.cis.luxoft.com/view/RPR%20Plugins/job/RadeonProRenderBlender2.8PluginManual/1013/Test_20Report/