### PR TITLE
New cases to Volume and Denoiser groups

### DIFF
--- a/jobs/Tests/Cloud/test_cases.json
+++ b/jobs/Tests/Cloud/test_cases.json
@@ -8,7 +8,10 @@
         "script_info": [
             "Blender_2_81_the_junk_Shop"
         ],
-        "scene": "Blender_2_81_the_junk_Shop.blend"
+        "scene": "Blender_2_81_the_junk_Shop.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_BCS_002",
@@ -23,7 +26,10 @@
         "script_info": [
             "Blender_2_80_Spring"
         ],
-        "scene": "Blender_2_80_Spring.blend"
+        "scene": "Blender_2_80_Spring.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_BCS_003",
@@ -38,7 +44,10 @@
         "script_info": [
             "Blender_2_79_Agent_327"
         ],
-        "scene": "Blender_2_79_Agent_327.blend"
+        "scene": "Blender_2_79_Agent_327.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_BCS_004",
@@ -51,7 +60,10 @@
         "script_info": [
             "Blender_2_78_Procedural"
         ],
-        "scene": "Blender_2_78_Procedural.blend"
+        "scene": "Blender_2_78_Procedural.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_BCS_005",
@@ -79,7 +91,10 @@
         "script_info": [
             "Blender_2_74_Fishy_Cat"
         ],
-        "scene": "Blender_2_74_Fishy_Cat.blend"
+        "scene": "Blender_2_74_Fishy_Cat.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_BCS_007",
@@ -96,7 +111,10 @@
         "script_info": [
             "Race_Spaceship"
         ],
-        "scene": "Race_Spaceship.blend"
+        "scene": "Race_Spaceship.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_BCS_008",
@@ -109,7 +127,10 @@
         "script_info": [
             "Tree_Creature"
         ],
-        "scene": "Tree_Creature.blend"
+        "scene": "Tree_Creature.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_BCS_009",
@@ -122,7 +143,10 @@
         "script_info": [
             "Temple"
         ],
-        "scene": "Temple.blend"
+        "scene": "Temple.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_BCS_010",
@@ -137,7 +161,10 @@
         "script_info": [
             "Wanderer"
         ],
-        "scene": "Wanderer.blend"
+        "scene": "Wanderer.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_BCS_011",
@@ -150,7 +177,10 @@
         "script_info": [
             "Ember_Forest"
         ],
-        "scene": "Ember_Forest.blend"
+        "scene": "Ember_Forest.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_BCS_012",
@@ -165,7 +195,10 @@
         "script_info": [
             "Wasp_Bot"
         ],
-        "scene": "Wasp_Bot.blend"
+        "scene": "Wasp_Bot.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_BCS_013",
@@ -178,7 +211,10 @@
         "script_info": [
             "Mr_Elephant"
         ],
-        "scene": "Mr_Elephant.blend"
+        "scene": "Mr_Elephant.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_BCS_014",
@@ -189,7 +225,10 @@
         "script_info": [
             "Architectural_Visualization_RPR"
         ],
-        "scene": "Architectural_Visualization_RPR.blend"
+        "scene": "Architectural_Visualization_RPR.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_BCS_015",
@@ -200,7 +239,10 @@
         "script_info": [
             "Agent_327_Barbershop"
         ],
-        "scene": "Agent_327_Barbershop.blend"
+        "scene": "Agent_327_Barbershop.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_BCS_016",
@@ -214,7 +256,10 @@
         "script_info": [
             "Cosmos_Laudromat_Demo"
         ],
-        "scene": "Cosmos_Laudromat_Demo.blend"
+        "scene": "Cosmos_Laudromat_Demo.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_BCS_017",
@@ -229,7 +274,10 @@
         "script_info": [
             "Car_Demo"
         ],
-        "scene": "Car_Demo.blend"
+        "scene": "Car_Demo.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_BCS_018",
@@ -244,7 +292,10 @@
         "script_info": [
             "classroom"
         ],
-        "scene": "classroom.blend"
+        "scene": "classroom.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_BCS_019",
@@ -260,7 +311,10 @@
         "script_info": [
             "Barcelona_Pavillion"
         ],
-        "scene": "Barcelona_Pavillion.blend"
+        "scene": "Barcelona_Pavillion.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_BCS_020",
@@ -271,7 +325,10 @@
         "script_info": [
             "Car_Viewport"
         ],
-        "scene": "Car_Viewport.blend"
+        "scene": "Car_Viewport.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_BCS_021",
@@ -282,7 +339,10 @@
         "script_info": [
             "stylized_levi"
         ],
-        "scene": "stylized_levi.blend"
+        "scene": "stylized_levi.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_BCS_022",
@@ -295,7 +355,10 @@
         "script_info": [
             "bmps_27"
         ],
-        "scene": "bmps_27.blend"
+        "scene": "bmps_27.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_BCS_023",
@@ -308,7 +371,10 @@
         "script_info": [
             "Ring_27"
         ],
-        "scene": "Ring_27.blend"
+        "scene": "Ring_27.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_BCS_024",
@@ -323,7 +389,10 @@
         "script_info": [
             "scene_Helicopter_27"
         ],
-        "scene": "scene_Helicopter_27.blend"
+        "scene": "scene_Helicopter_27.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_BCS_025",
@@ -338,7 +407,10 @@
         "script_info": [
             "TeeglasFX_27"
         ],
-        "scene": "TeeglasFX_27.blend"
+        "scene": "TeeglasFX_27.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_BCS_026",

--- a/jobs/Tests/Cloud/test_cases.json
+++ b/jobs/Tests/Cloud/test_cases.json
@@ -79,7 +79,7 @@
         ],
         "scene": "Blender_2_77_Racing_Car.blend",
         "skip_on": [
-            [["GeForce GTX 1080 Ti"], ["AMD Radeon VII"]]
+            ["GeForce GTX 1080 Ti"], ["AMD Radeon VII"]
         ]
     },
     {

--- a/jobs/Tests/Cloud/test_cases.json
+++ b/jobs/Tests/Cloud/test_cases.json
@@ -79,7 +79,7 @@
         ],
         "scene": "Blender_2_77_Racing_Car.blend",
         "skip_on": [
-            ["GeForce GTX 1080 Ti"]
+            ["GeForce GTX 1080 Ti", "AMD Radeon VII"]
         ]
     },
     {
@@ -423,6 +423,9 @@
         "script_info": [
             "volume_emission_27"
         ],
-        "scene": "volume_emission_27.blend"
+        "scene": "volume_emission_27.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     }
 ]

--- a/jobs/Tests/Cloud/test_cases.json
+++ b/jobs/Tests/Cloud/test_cases.json
@@ -79,7 +79,7 @@
         ],
         "scene": "Blender_2_77_Racing_Car.blend",
         "skip_on": [
-            ["GeForce GTX 1080 Ti", "AMD Radeon VII"]
+            [["GeForce GTX 1080 Ti"], ["AMD Radeon VII"]]
         ]
     },
     {

--- a/jobs/Tests/Denoiser/test_cases.json
+++ b/jobs/Tests/Denoiser/test_cases.json
@@ -1246,5 +1246,381 @@
             "Denoiser type: Bilateral"
         ],
         "scene": "DenoiserMaterials.blend"
+    },
+    {
+        "case": "BL28_RS_DEN_071",
+        "status": "active",
+        "functions": [
+            "view_layer = bpy.context.view_layer",
+            "set_value(view_layer.rpr.denoiser, 'enable', True)",
+            "set_value(view_layer.rpr.denoiser, 'filter_type', 'ML')",
+            "set_value(view_layer.rpr.denoiser, 'ml_color_only', True)",
+            "set_value(bpy.data.objects['Plane01'].rpr, 'shadowcatcher', True)",
+            "rpr_render(case)",
+            "set_value(bpy.data.objects['Plane01'].rpr, 'shadowcatcher', False)",
+            "resetSceneAttributes()"
+        ],
+        "script_info": [
+            "Shadow catcher",
+            "Denoiser type: ML",
+            "Use Color AOV: True"
+        ],
+        "scene": "DenoiserMaterials.blend"
+    },
+    {
+        "case": "BL28_RS_DEN_072",
+        "status": "active",
+        "functions": [
+            "view_layer = bpy.context.view_layer",
+            "set_value(view_layer.rpr.denoiser, 'enable', True)",
+            "set_value(view_layer.rpr.denoiser, 'filter_type', 'ML')",
+            "set_value(view_layer.rpr.denoiser, 'ml_color_only', False)",
+            "set_value(bpy.data.objects['Plane01'].rpr, 'shadowcatcher', True)",
+            "rpr_render(case)",
+            "set_value(bpy.data.objects['Plane01'].rpr, 'shadowcatcher', False)",
+            "resetSceneAttributes()"
+        ],
+        "script_info": [
+            "Shadow catcher",
+            "Denoiser type: ML",
+            "Use Color AOV: False"
+        ],
+        "scene": "DenoiserMaterials.blend"
+    },
+    {
+        "case": "BL28_RS_DEN_073",
+        "status": "active",
+        "functions": [
+            "view_layer = bpy.context.view_layer",
+            "set_value(view_layer.rpr.denoiser, 'enable', True)",
+            "set_value(view_layer.rpr.denoiser, 'filter_type', 'EAW')",
+            "set_value(bpy.data.objects['Plane01'].rpr, 'shadowcatcher', True)",
+            "rpr_render(case)",
+            "set_value(bpy.data.objects['Plane01'].rpr, 'shadowcatcher', False)",
+            "resetSceneAttributes()"
+        ],
+        "script_info": [
+            "Shadow catcher",
+            "Denoiser type: EAW"
+        ],
+        "scene": "DenoiserMaterials.blend"
+    },
+    {
+        "case": "BL28_RS_DEN_074",
+        "status": "active",
+        "functions": [
+            "view_layer = bpy.context.view_layer",
+            "set_value(view_layer.rpr.denoiser, 'enable', True)",
+            "set_value(view_layer.rpr.denoiser, 'filter_type', 'LWR')",
+            "set_value(bpy.data.objects['Plane01'].rpr, 'shadowcatcher', True)",
+            "rpr_render(case)",
+            "set_value(bpy.data.objects['Plane01'].rpr, 'shadowcatcher', False)",
+            "resetSceneAttributes()"
+        ],
+        "script_info": [
+            "Shadow catcher",
+            "Denoiser type: LWR"
+        ],
+        "scene": "DenoiserMaterials.blend"
+    },
+    {
+        "case": "BL28_RS_DEN_075",
+        "status": "active",
+        "functions": [
+            "view_layer = bpy.context.view_layer",
+            "set_value(view_layer.rpr.denoiser, 'enable', True)",
+            "set_value(view_layer.rpr.denoiser, 'filter_type', 'BILATERAL')",
+            "set_value(bpy.data.objects['Plane01'].rpr, 'shadowcatcher', True)",
+            "rpr_render(case)",
+            "set_value(bpy.data.objects['Plane01'].rpr, 'shadowcatcher', False)",
+            "resetSceneAttributes()"
+        ],
+        "script_info": [
+            "Shadow catcher",
+            "Denoiser type: Bilateral"
+        ],
+        "scene": "DenoiserMaterials.blend"
+    },
+    {
+        "case": "BL28_RS_DEN_076",
+        "status": "active",
+        "functions": [
+            "view_layer = bpy.context.view_layer",
+            "set_value(view_layer.rpr.denoiser, 'enable', True)",
+            "set_value(view_layer.rpr.denoiser, 'filter_type', 'ML')",
+            "set_value(view_layer.rpr.denoiser, 'ml_color_only', True)",
+            "set_value(bpy.data.objects['Plane01'].rpr, 'reflection_catcher', True)",
+            "rpr_render(case)",
+            "set_value(bpy.data.objects['Plane01'].rpr, 'reflection_catcher', False)",
+            "resetSceneAttributes()"
+        ],
+        "script_info": [
+            "Reflection catcher",
+            "Denoiser type: ML",
+            "Use Color AOV: True"
+        ],
+        "scene": "DenoiserMaterials.blend"
+    },
+    {
+        "case": "BL28_RS_DEN_077",
+        "status": "active",
+        "functions": [
+            "view_layer = bpy.context.view_layer",
+            "set_value(view_layer.rpr.denoiser, 'enable', True)",
+            "set_value(view_layer.rpr.denoiser, 'filter_type', 'ML')",
+            "set_value(view_layer.rpr.denoiser, 'ml_color_only', False)",
+            "set_value(bpy.data.objects['Plane01'].rpr, 'reflection_catcher', True)",
+            "rpr_render(case)",
+            "set_value(bpy.data.objects['Plane01'].rpr, 'reflection_catcher', False)",
+            "resetSceneAttributes()"
+        ],
+        "script_info": [
+            "Reflection catcher",
+            "Denoiser type: ML",
+            "Use Color AOV: False"
+        ],
+        "scene": "DenoiserMaterials.blend"
+    },
+    {
+        "case": "BL28_RS_DEN_078",
+        "status": "active",
+        "functions": [
+            "view_layer = bpy.context.view_layer",
+            "set_value(view_layer.rpr.denoiser, 'enable', True)",
+            "set_value(view_layer.rpr.denoiser, 'filter_type', 'EAW')",
+            "set_value(bpy.data.objects['Plane01'].rpr, 'reflection_catcher', True)",
+            "rpr_render(case)",
+            "set_value(bpy.data.objects['Plane01'].rpr, 'reflection_catcher', False)",
+            "resetSceneAttributes()"
+        ],
+        "script_info": [
+            "Reflection catcher",
+            "Denoiser type: EAW"
+        ],
+        "scene": "DenoiserMaterials.blend"
+    },
+    {
+        "case": "BL28_RS_DEN_079",
+        "status": "active",
+        "functions": [
+            "view_layer = bpy.context.view_layer",
+            "set_value(view_layer.rpr.denoiser, 'enable', True)",
+            "set_value(view_layer.rpr.denoiser, 'filter_type', 'LWR')",
+            "set_value(bpy.data.objects['Plane01'].rpr, 'reflection_catcher', True)",
+            "rpr_render(case)",
+            "set_value(bpy.data.objects['Plane01'].rpr, 'reflection_catcher', False)",
+            "resetSceneAttributes()"
+        ],
+        "script_info": [
+            "Reflection catcher",
+            "Denoiser type: LWR"
+        ],
+        "scene": "DenoiserMaterials.blend"
+    },
+    {
+        "case": "BL28_RS_DEN_080",
+        "status": "active",
+        "functions": [
+            "view_layer = bpy.context.view_layer",
+            "set_value(view_layer.rpr.denoiser, 'enable', True)",
+            "set_value(view_layer.rpr.denoiser, 'filter_type', 'BILATERAL')",
+            "set_value(bpy.data.objects['Plane01'].rpr, 'reflection_catcher', True)",
+            "rpr_render(case)",
+            "set_value(bpy.data.objects['Plane01'].rpr, 'reflection_catcher', False)",
+            "resetSceneAttributes()"
+        ],
+        "script_info": [
+            "Reflection catcher",
+            "Denoiser type: Bilateral"
+        ],
+        "scene": "DenoiserMaterials.blend"
+    },
+    {
+        "case": "BL28_RS_DEN_081",
+        "status": "active",
+        "functions": [
+            "view_layer = bpy.context.view_layer",
+            "set_value(view_layer.rpr.denoiser, 'enable', True)",
+            "set_value(view_layer.rpr.denoiser, 'filter_type', 'ML')",
+            "set_value(view_layer.rpr.denoiser, 'ml_color_only', True)",
+            "set_value(bpy.context.scene.render, 'film_transparent', True)",
+            "rpr_render(case)",
+            "set_value(bpy.context.scene.render, 'film_transparent', False)",
+            "resetSceneAttributes()"
+        ],
+        "script_info": [
+            "Transparent background",
+            "Denoiser type: ML",
+            "Use Color AOV: True"
+        ],
+        "scene": "DenoiserMaterials.blend"
+    },
+    {
+        "case": "BL28_RS_DEN_082",
+        "status": "active",
+        "functions": [
+            "view_layer = bpy.context.view_layer",
+            "set_value(view_layer.rpr.denoiser, 'enable', True)",
+            "set_value(view_layer.rpr.denoiser, 'filter_type', 'ML')",
+            "set_value(view_layer.rpr.denoiser, 'ml_color_only', False)",
+            "set_value(bpy.context.scene.render, 'film_transparent', True)",
+            "rpr_render(case)",
+            "set_value(bpy.context.scene.render, 'film_transparent', False)",
+            "resetSceneAttributes()"
+        ],
+        "script_info": [
+            "Transparent background",
+            "Denoiser type: ML",
+            "Use Color AOV: False"
+        ],
+        "scene": "DenoiserMaterials.blend"
+    },
+    {
+        "case": "BL28_RS_DEN_083",
+        "status": "active",
+        "functions": [
+            "view_layer = bpy.context.view_layer",
+            "set_value(view_layer.rpr.denoiser, 'enable', True)",
+            "set_value(view_layer.rpr.denoiser, 'filter_type', 'EAW')",
+            "set_value(bpy.context.scene.render, 'film_transparent', True)",
+            "rpr_render(case)",
+            "set_value(bpy.context.scene.render, 'film_transparent', False)",
+            "resetSceneAttributes()"
+        ],
+        "script_info": [
+            "Transparent background",
+            "Denoiser type: EAW"
+        ],
+        "scene": "DenoiserMaterials.blend"
+    },
+    {
+        "case": "BL28_RS_DEN_084",
+        "status": "active",
+        "functions": [
+            "view_layer = bpy.context.view_layer",
+            "set_value(view_layer.rpr.denoiser, 'enable', True)",
+            "set_value(view_layer.rpr.denoiser, 'filter_type', 'LWR')",
+            "set_value(bpy.context.scene.render, 'film_transparent', True)",
+            "rpr_render(case)",
+            "set_value(bpy.context.scene.render, 'film_transparent', False)",
+            "resetSceneAttributes()"
+        ],
+        "script_info": [
+            "Transparent background",
+            "Denoiser type: LWR"
+        ],
+        "scene": "DenoiserMaterials.blend"
+    },
+    {
+        "case": "BL28_RS_DEN_085",
+        "status": "active",
+        "functions": [
+            "view_layer = bpy.context.view_layer",
+            "set_value(view_layer.rpr.denoiser, 'enable', True)",
+            "set_value(view_layer.rpr.denoiser, 'filter_type', 'BILATERAL')",
+            "set_value(bpy.context.scene.render, 'film_transparent', True)",
+            "rpr_render(case)",
+            "set_value(bpy.context.scene.render, 'film_transparent', False)",
+            "resetSceneAttributes()"
+        ],
+        "script_info": [
+            "Transparent background",
+            "Denoiser type: Bilateral"
+        ],
+        "scene": "DenoiserMaterials.blend"
+    },
+    {
+        "case": "BL28_RS_DEN_086",
+        "status": "active",
+        "functions": [
+            "view_layer = bpy.context.view_layer",
+            "set_value(view_layer.rpr.denoiser, 'enable', True)",
+            "set_value(view_layer.rpr.denoiser, 'filter_type', 'ML')",
+            "set_value(view_layer.rpr.denoiser, 'ml_color_only', True)",
+            "set_value(bpy.context.scene.rpr, 'use_tile_render', True)",
+            "rpr_render(case)",
+            "set_value(bpy.context.scene.rpr, 'use_tile_render', False)",
+            "resetSceneAttributes()"
+        ],
+        "script_info": [
+            "Tile rendering",
+            "Denoiser type: ML",
+            "Use Color AOV: True"
+        ],
+        "scene": "DenoiserMaterials.blend"
+    },
+    {
+        "case": "BL28_RS_DEN_087",
+        "status": "active",
+        "functions": [
+            "view_layer = bpy.context.view_layer",
+            "set_value(view_layer.rpr.denoiser, 'enable', True)",
+            "set_value(view_layer.rpr.denoiser, 'filter_type', 'ML')",
+            "set_value(view_layer.rpr.denoiser, 'ml_color_only', False)",
+            "set_value(bpy.context.scene.rpr, 'use_tile_render', True)",
+            "rpr_render(case)",
+            "set_value(bpy.context.scene.rpr, 'use_tile_render', False)",
+            "resetSceneAttributes()"
+        ],
+        "script_info": [
+            "Tile rendering",
+            "Denoiser type: ML",
+            "Use Color AOV: False"
+        ],
+        "scene": "DenoiserMaterials.blend"
+    },
+    {
+        "case": "BL28_RS_DEN_088",
+        "status": "active",
+        "functions": [
+            "view_layer = bpy.context.view_layer",
+            "set_value(view_layer.rpr.denoiser, 'enable', True)",
+            "set_value(view_layer.rpr.denoiser, 'filter_type', 'EAW')",
+            "set_value(bpy.context.scene.rpr, 'use_tile_render', True)",
+            "rpr_render(case)",
+            "set_value(bpy.context.scene.rpr, 'use_tile_render', False)",
+            "resetSceneAttributes()"
+        ],
+        "script_info": [
+            "Tile rendering",
+            "Denoiser type: EAW"
+        ],
+        "scene": "DenoiserMaterials.blend"
+    },
+    {
+        "case": "BL28_RS_DEN_089",
+        "status": "active",
+        "functions": [
+            "view_layer = bpy.context.view_layer",
+            "set_value(view_layer.rpr.denoiser, 'enable', True)",
+            "set_value(view_layer.rpr.denoiser, 'filter_type', 'LWR')",
+            "set_value(bpy.context.scene.rpr, 'use_tile_render', True)",
+            "rpr_render(case)",
+            "set_value(bpy.context.scene.rpr, 'use_tile_render', False)",
+            "resetSceneAttributes()"
+        ],
+        "script_info": [
+            "Tile rendering",
+            "Denoiser type: LWR"
+        ],
+        "scene": "DenoiserMaterials.blend"
+    },
+    {
+        "case": "BL28_RS_DEN_090",
+        "status": "active",
+        "functions": [
+            "view_layer = bpy.context.view_layer",
+            "set_value(view_layer.rpr.denoiser, 'enable', True)",
+            "set_value(view_layer.rpr.denoiser, 'filter_type', 'BILATERAL')",
+            "set_value(bpy.context.scene.rpr, 'use_tile_render', True)",
+            "rpr_render(case)",
+            "set_value(bpy.context.scene.rpr, 'use_tile_render', False)",
+            "resetSceneAttributes()"
+        ],
+        "script_info": [
+            "Tile rendering",
+            "Denoiser type: Bilateral"
+        ],
+        "scene": "DenoiserMaterials.blend"
     }
 ]

--- a/jobs/Tests/Denoiser/test_cases.json
+++ b/jobs/Tests/Denoiser/test_cases.json
@@ -478,7 +478,7 @@
     },
     {
         "case": "BL28_RS_DEN_028",
-        "status": "active",
+        "status": "skipped",
         "functions": [
             "view_layer = bpy.context.view_layer",
             "set_value(view_layer.rpr.denoiser, 'enable', True)",
@@ -496,7 +496,7 @@
     },
     {
         "case": "BL28_RS_DEN_029",
-        "status": "active",
+        "status": "skipped",
         "functions": [
             "view_layer = bpy.context.view_layer",
             "set_value(view_layer.rpr.denoiser, 'enable', True)",
@@ -565,7 +565,7 @@
     },
     {
         "case": "BL28_RS_DEN_033",
-        "status": "active",
+        "status": "skipped",
         "functions": [
             "view_layer = bpy.context.view_layer",
             "set_value(view_layer.rpr.denoiser, 'enable', True)",
@@ -1042,7 +1042,10 @@
             "Denoiser type: ML",
             "Use Color AOV: False"
         ],
-        "scene": "DenoiserIBL.blend"
+        "scene": "DenoiserIBL.blend",
+        "skip_on": [
+            ["GeForce GTX 1080 Ti"]
+        ]
     },
     {
         "case": "BL28_RS_DEN_058",
@@ -1057,7 +1060,10 @@
         "script_info": [
             "Denoiser type: EAW"
         ],
-        "scene": "DenoiserIBL.blend"
+        "scene": "DenoiserIBL.blend",
+        "skip_on": [
+            ["GeForce GTX 1080 Ti"]
+        ]
     },
     {
         "case": "BL28_RS_DEN_059",

--- a/jobs/Tests/Denoiser/test_cases.json
+++ b/jobs/Tests/Denoiser/test_cases.json
@@ -14,7 +14,7 @@
             "Denoiser type: Bilateral",
             "Radius: 1"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_002",
@@ -31,7 +31,7 @@
             "Denoiser type: Bilateral",
             "Radius: 5"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_003",
@@ -48,7 +48,7 @@
             "Denoiser type: Bilateral",
             "Radius: 10"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_004",
@@ -63,7 +63,7 @@
         "script_info": [
             "Denoiser type: LWR"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_005",
@@ -80,7 +80,7 @@
             "Denoiser type: LWR",
             "Samples: 5"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_006",
@@ -97,7 +97,7 @@
             "Denoiser type: LWR",
             "Samples: 10"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_007",
@@ -114,7 +114,7 @@
             "Denoiser type: LWR",
             "Filter radius: 5"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_008",
@@ -131,7 +131,7 @@
             "Denoiser type: LWR",
             "Filter radius: 10"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_009",
@@ -148,7 +148,7 @@
             "Denoiser type: LWR",
             "Bandwidth: 0.1"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_010",
@@ -165,7 +165,7 @@
             "Denoiser type: LWR",
             "Bandwidth: 0.5"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_011",
@@ -186,7 +186,7 @@
             "Filter radius: 1",
             "Bandwidth: 0.1"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_012",
@@ -207,7 +207,7 @@
             "Filter radius: 5",
             "Bandwidth: 0.5"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_013",
@@ -228,7 +228,7 @@
             "Filter radius: 10",
             "Bandwidth: 1"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_014",
@@ -243,7 +243,7 @@
         "script_info": [
             "Denoiser type: EAW"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_015",
@@ -260,7 +260,7 @@
             "Denoiser type: EAW",
             "Color: 0.1"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_016",
@@ -277,7 +277,7 @@
             "Denoiser type: EAW",
             "Color: 0.5"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_017",
@@ -294,7 +294,7 @@
             "Denoiser type: EAW",
             "Depth: 0.1"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_018",
@@ -311,7 +311,7 @@
             "Denoiser type: EAW",
             "Depth: 0.5"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_019",
@@ -328,7 +328,7 @@
             "Denoiser type: EAW",
             "Normal: 0.1"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_020",
@@ -345,7 +345,7 @@
             "Denoiser type: EAW",
             "Normal: 0.5"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_021",
@@ -362,7 +362,7 @@
             "Denoiser type: EAW",
             "Trans: 0.1"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_022",
@@ -379,7 +379,7 @@
             "Denoiser type: EAW",
             "Trans: 0.5"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_023",
@@ -402,7 +402,7 @@
             "Normal: 0.1",
             "Trans: 0.1"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_024",
@@ -425,7 +425,7 @@
             "Normal: 0.5",
             "Trans: 0.5"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_025",
@@ -440,7 +440,7 @@
         "script_info": [
             "Denoiser type: ML"
         ],
-        "scene": "Test_Scene.blend"
+        "scene": "DualCpu.blend"
     },
     {
         "case": "BL28_RS_DEN_026",

--- a/jobs/Tests/Denoiser/test_cases.json
+++ b/jobs/Tests/Denoiser/test_cases.json
@@ -478,7 +478,7 @@
     },
     {
         "case": "BL28_RS_DEN_028",
-        "status": "skipped",
+        "status": "active",
         "functions": [
             "view_layer = bpy.context.view_layer",
             "set_value(view_layer.rpr.denoiser, 'enable', True)",
@@ -496,7 +496,7 @@
     },
     {
         "case": "BL28_RS_DEN_029",
-        "status": "skipped",
+        "status": "active",
         "functions": [
             "view_layer = bpy.context.view_layer",
             "set_value(view_layer.rpr.denoiser, 'enable', True)",
@@ -565,7 +565,7 @@
     },
     {
         "case": "BL28_RS_DEN_033",
-        "status": "skipped",
+        "status": "active",
         "functions": [
             "view_layer = bpy.context.view_layer",
             "set_value(view_layer.rpr.denoiser, 'enable', True)",
@@ -1012,7 +1012,7 @@
     },
     {
         "case": "BL28_RS_DEN_056",
-        "status": "skipped",
+        "status": "active",
         "functions": [
             "view_layer = bpy.context.view_layer",
             "set_value(view_layer.rpr.denoiser, 'enable', True)",
@@ -1029,7 +1029,7 @@
     },
     {
         "case": "BL28_RS_DEN_057",
-        "status": "skipped",
+        "status": "active",
         "functions": [
             "view_layer = bpy.context.view_layer",
             "set_value(view_layer.rpr.denoiser, 'enable', True)",

--- a/jobs/Tests/Smoke/test_cases.json
+++ b/jobs/Tests/Smoke/test_cases.json
@@ -400,7 +400,7 @@
 			"Denoiser EAW",
 			"Pass Limit: 50"
 		],
-		"scene": "default.blend"
+		"scene": "DualCpu.blend"
 	},
 	{
 		"case": "BL28_SM_026",
@@ -418,7 +418,7 @@
 			"Denoiser LWR",
 			"Pass Limit: 50"
 		],
-		"scene": "default.blend"
+		"scene": "DualCpu.blend"
 	},
 	{
 		"case": "BL28_SM_027",
@@ -436,7 +436,7 @@
 			"Denoiser Bilateral",
 			"Pass Limit: 50"
 		],
-		"scene": "default.blend"
+		"scene": "DualCpu.blend"
 	},
 	{
 		"case": "BL28_SM_028",
@@ -454,7 +454,7 @@
 			"Denoiser ML",
 			"Pass Limit: 50"
 		],
-		"scene": "default.blend"
+		"scene": "DualCpu.blend"
 	},
 	{
 		"case": "BL28_SM_029",

--- a/jobs/Tests/Volume/test_cases.json
+++ b/jobs/Tests/Volume/test_cases.json
@@ -299,7 +299,7 @@
     },
     {
         "case": "BL28_MAT_VM_022",
-        "status": "active",
+        "status": "skipped",
         "script_info": [
             "Volume Anisotropy Color Checker texture"
         ],
@@ -316,7 +316,7 @@
     },
     {
         "case": "BL28_MAT_VM_023",
-        "status": "active",
+        "status": "skipped",
         "script_info": [
             "Volume Anisotropy Color .tga"
         ],
@@ -333,7 +333,7 @@
     },
     {
         "case": "BL28_MAT_VM_024",
-        "status": "active",
+        "status": "skipped",
         "script_info": [
             "Volume Anisotropy Color .png"
         ],

--- a/jobs/Tests/Volume/test_cases.json
+++ b/jobs/Tests/Volume/test_cases.json
@@ -572,7 +572,8 @@
             "volume_node.inputs['Density'].default_value = 1",
             "volume_node.inputs['Blackbody Intensity'].default_value = 1",
             "volume_node.inputs['Blackbody Tint'].default_value = (0.5, 0.5, 0.5, 1)",
-            "rpr_render(case)"
+            "rpr_render(case)",
+            "bpy.ops.wm.open_mainfile(filepath=os.path.join(RES_PATH, 'Volume.blend'))"
         ]
     },
     {
@@ -589,7 +590,8 @@
             "volume_node.inputs['Density'].default_value = 1",
             "volume_node.inputs['Blackbody Intensity'].default_value = 1",
             "volume_node.inputs['Blackbody Tint'].default_value = (0.5, 0.5, 0.5, 1)",
-            "rpr_render(case)"
+            "rpr_render(case)",
+            "bpy.ops.wm.open_mainfile(filepath=os.path.join(RES_PATH, 'Volume.blend'))"
         ]
     },
     {
@@ -606,7 +608,8 @@
             "volume_node.inputs['Density'].default_value = 1",
             "volume_node.inputs['Blackbody Intensity'].default_value = 1",
             "volume_node.inputs['Blackbody Tint'].default_value = (0.5, 0.5, 0.5, 1)",
-            "rpr_render(case)"
+            "rpr_render(case)",
+            "delete_imagemap()"
         ]
     },
     {
@@ -623,7 +626,8 @@
             "volume_node.inputs['Density'].default_value = 1",
             "volume_node.inputs['Blackbody Intensity'].default_value = 1",
             "volume_node.inputs['Blackbody Tint'].default_value = (0.5, 0.5, 0.5, 1)",
-            "rpr_render(case)"
+            "rpr_render(case)",
+            "delete_imagemap()"
         ]
     },
     {

--- a/jobs/Tests/Volume/test_cases.json
+++ b/jobs/Tests/Volume/test_cases.json
@@ -496,67 +496,187 @@
     },
     {
         "case": "BL28_MAT_VM_033",
-        "status": "skipped",
+        "status": "active",
         "script_info": [
             "Volume Blackbody Intencity - 0.5"
         ],
         "scene": "Volume.blend",
         "functions": [
+            "volume_material, volume_node = get_material_and_node()",
+            "volume_node.inputs['Color'].default_value = (0.5, 0.5, 0.5, 1)",
+            "volume_node.inputs['Density'].default_value = 1",
+            "volume_node.inputs['Blackbody Intensity'].default_value = 0.5",
+            "volume_node.inputs['Blackbody Tint'].default_value = (0.5, 0.5, 0.5, 1)",
             "rpr_render(case)"
         ]
     },
     {
         "case": "BL28_MAT_VM_034",
-        "status": "skipped",
+        "status": "active",
         "script_info": [
-            "Volume Blackbody Intencity- 0.6"
+            "Volume Blackbody Intencity- 1"
         ],
         "scene": "Volume.blend",
         "functions": [
+            "volume_material, volume_node = get_material_and_node()",
+            "volume_node.inputs['Color'].default_value = (0.5, 0.5, 0.5, 1)",
+            "volume_node.inputs['Density'].default_value = 1",
+            "volume_node.inputs['Blackbody Intensity'].default_value = 1",
+            "volume_node.inputs['Blackbody Tint'].default_value = (0.5, 0.5, 0.5, 1)",
             "rpr_render(case)"
         ]
     },
     {
         "case": "BL28_MAT_VM_035",
-        "status": "skipped",
+        "status": "active",
         "script_info": [
-            "Volume Blackbody Intencity Checker texture"
+            "Volume Blackbody Intencity - 5"
         ],
         "scene": "Volume.blend",
         "functions": [
+            "volume_material, volume_node = get_material_and_node()",
+            "volume_node.inputs['Color'].default_value = (0.5, 0.5, 0.5, 1)",
+            "volume_node.inputs['Density'].default_value = 1",
+            "volume_node.inputs['Blackbody Intensity'].default_value = 5",
+            "volume_node.inputs['Blackbody Tint'].default_value = (0.5, 0.5, 0.5, 1)",
             "rpr_render(case)"
         ]
     },
     {
         "case": "BL28_MAT_VM_036",
-        "status": "skipped",
+        "status": "active",
         "script_info": [
-            "Volume Blackbody Tint Checker texture"
+            "Volume Blackbody Intencity - 10"
         ],
         "scene": "Volume.blend",
         "functions": [
+            "volume_material, volume_node = get_material_and_node()",
+            "volume_node.inputs['Color'].default_value = (0.5, 0.5, 0.5, 1)",
+            "volume_node.inputs['Density'].default_value = 1",
+            "volume_node.inputs['Blackbody Intensity'].default_value = 10",
+            "volume_node.inputs['Blackbody Tint'].default_value = (0.5, 0.5, 0.5, 1)",
             "rpr_render(case)"
         ]
     },
     {
         "case": "BL28_MAT_VM_037",
-        "status": "skipped",
+        "status": "active",
         "script_info": [
-            "Volume Blackbody Tint .tga"
+            "Volume Blackbody Intencity Checker texture"
         ],
         "scene": "Volume.blend",
         "functions": [
+            "volume_material, volume_node = get_material_and_node()",
+            "create_checker_texture('Blackbody Intencity')",
+            "volume_node.inputs['Color'].default_value = (0.5, 0.5, 0.5, 1)",
+            "volume_node.inputs['Density'].default_value = 1",
+            "volume_node.inputs['Blackbody Intensity'].default_value = 1",
+            "volume_node.inputs['Blackbody Tint'].default_value = (0.5, 0.5, 0.5, 1)",
             "rpr_render(case)"
         ]
     },
     {
         "case": "BL28_MAT_VM_038",
-        "status": "skipped",
+        "status": "active",
+        "script_info": [
+            "Volume Blackbody Tint Checker texture"
+        ],
+        "scene": "Volume.blend",
+        "functions": [
+            "volume_material, volume_node = get_material_and_node()",
+            "create_checker_texture('Blackbody Tint')",
+            "volume_node.inputs['Color'].default_value = (0.5, 0.5, 0.5, 1)",
+            "volume_node.inputs['Density'].default_value = 1",
+            "volume_node.inputs['Blackbody Intensity'].default_value = 1",
+            "volume_node.inputs['Blackbody Tint'].default_value = (0.5, 0.5, 0.5, 1)",
+            "rpr_render(case)"
+        ]
+    },
+    {
+        "case": "BL28_MAT_VM_039",
+        "status": "active",
+        "script_info": [
+            "Volume Blackbody Tint .tga"
+        ],
+        "scene": "Volume.blend",
+        "functions": [
+            "volume_material, volume_node = get_material_and_node()",
+            "create_imagemap('Blackbody Tint', 'transmissionColor.tga')",
+            "volume_node.inputs['Color'].default_value = (0.5, 0.5, 0.5, 1)",
+            "volume_node.inputs['Density'].default_value = 1",
+            "volume_node.inputs['Blackbody Intensity'].default_value = 1",
+            "volume_node.inputs['Blackbody Tint'].default_value = (0.5, 0.5, 0.5, 1)",
+            "rpr_render(case)"
+        ]
+    },
+    {
+        "case": "BL28_MAT_VM_040",
+        "status": "active",
         "script_info": [
             "Volume Blackbody Tint .png"
         ],
         "scene": "Volume.blend",
         "functions": [
+            "volume_material, volume_node = get_material_and_node()",
+            "create_imagemap('Blackbody Tint', 'transmissionColor.png')",
+            "volume_node.inputs['Color'].default_value = (0.5, 0.5, 0.5, 1)",
+            "volume_node.inputs['Density'].default_value = 1",
+            "volume_node.inputs['Blackbody Intensity'].default_value = 1",
+            "volume_node.inputs['Blackbody Tint'].default_value = (0.5, 0.5, 0.5, 1)",
+            "rpr_render(case)"
+        ]
+    },
+    {
+        "case": "BL28_MAT_VM_041",
+        "status": "active",
+        "script_info": [
+            "Volume Blackbody Temperature - 2400"
+        ],
+        "scene": "Volume.blend",
+        "functions": [
+            "volume_material, volume_node = get_material_and_node()",
+            "create_imagemap('Blackbody Tint', 'transmissionColor.tga')",
+            "volume_node.inputs['Color'].default_value = (0.5, 0.5, 0.5, 1)",
+            "volume_node.inputs['Density'].default_value = 1",
+            "volume_node.inputs['Blackbody Intensity'].default_value = 1",
+            "volume_node.inputs['Blackbody Tint'].default_value = (1, 1, 1, 1)",
+            "volume_node.inputs['Temperature'].default_value = 2400",
+            "rpr_render(case)"
+        ]
+    },
+    {
+        "case": "BL28_MAT_VM_042",
+        "status": "active",
+        "script_info": [
+            "Volume Blackbody Temperature - 3600"
+        ],
+        "scene": "Volume.blend",
+        "functions": [
+            "volume_material, volume_node = get_material_and_node()",
+            "create_imagemap('Blackbody Tint', 'transmissionColor.tga')",
+            "volume_node.inputs['Color'].default_value = (0.5, 0.5, 0.5, 1)",
+            "volume_node.inputs['Density'].default_value = 1",
+            "volume_node.inputs['Blackbody Intensity'].default_value = 1",
+            "volume_node.inputs['Blackbody Tint'].default_value = (1, 1, 1, 1)",
+            "volume_node.inputs['Temperature'].default_value = 3600",
+            "rpr_render(case)"
+        ]
+    },
+    {
+        "case": "BL28_MAT_VM_043",
+        "status": "active",
+        "script_info": [
+            "Volume Blackbody Temperature - 9200"
+        ],
+        "scene": "Volume.blend",
+        "functions": [
+            "volume_material, volume_node = get_material_and_node()",
+            "create_imagemap('Blackbody Tint', 'transmissionColor.tga')",
+            "volume_node.inputs['Color'].default_value = (0.5, 0.5, 0.5, 1)",
+            "volume_node.inputs['Density'].default_value = 1",
+            "volume_node.inputs['Blackbody Intensity'].default_value = 1",
+            "volume_node.inputs['Blackbody Tint'].default_value = (1, 1, 1, 1)",
+            "volume_node.inputs['Temperature'].default_value = 9200",
             "rpr_render(case)"
         ]
     }


### PR DESCRIPTION
**PURPOSE**
This branch adds new test cases to Volume and Denoiser groups, aswell as changes denoiser scene in Denoiser and Smoke groups to make it atleast somewhat complex. Also it skips Cloud group on Ubuntu, because it causes machine to freeze. Some denoiser cases were unskipped, because of "skip_on" function integration
**NOTES TO REVIEWERS**
2 cloud cases left were skipped on ubuntu after the build
**REPORTS**
https://rpr.cis.luxoft.com/view/RPR%20Plugins/job/RadeonProRenderBlender2.8PluginManual/1529/Test_20Report/