### PR TITLE
Skipped denoiser

### DIFF
--- a/jobs/Tests/Denoiser/test_cases.json
+++ b/jobs/Tests/Denoiser/test_cases.json
@@ -440,7 +440,10 @@
         "script_info": [
             "Denoiser type: ML"
         ],
-        "scene": "DualCpu.blend"
+        "scene": "DualCpu.blend",
+        "skip_on": [
+            ["AMD Radeon RX Vega 56 (Metal)"]
+        ]
     },
     {
         "case": "BL28_RS_DEN_026",
@@ -736,7 +739,7 @@
         ],
         "scene": "DenoiserLight.blend",
         "skip_on": [
-            ["AMD Radeon VII"]
+            ["AMD Radeon VII"], ["AMD Radeon RX Vega 56 (Metal)"]
         ]
     },
     {

--- a/jobs/Tests/Denoiser/test_cases.json
+++ b/jobs/Tests/Denoiser/test_cases.json
@@ -734,7 +734,10 @@
             "PhysicalLight2 intensity: 0",
             "IES intensity: 3"
         ],
-        "scene": "DenoiserLight.blend"
+        "scene": "DenoiserLight.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_RS_DEN_042",
@@ -757,7 +760,10 @@
             "PhysicalLight2 intensity: 0",
             "IES intensity: 3"
         ],
-        "scene": "DenoiserLight.blend"
+        "scene": "DenoiserLight.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_RS_DEN_043",
@@ -780,7 +786,10 @@
             "PhysicalLight2 intensity: 3",
             "IES intensity: 3"
         ],
-        "scene": "DenoiserLight.blend"
+        "scene": "DenoiserLight.blend",
+        "skip_on": [
+            ["AMD Radeon VII"], ["AMD Radeon RX Vega 56 (Metal)"]
+        ]
     },
     {
         "case": "BL28_RS_DEN_044",
@@ -803,7 +812,10 @@
             "PhysicalLight2 intensity: 3",
             "IES intensity: 3"
         ],
-        "scene": "DenoiserLight.blend"
+        "scene": "DenoiserLight.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_RS_DEN_045",
@@ -946,7 +958,10 @@
             "Denoiser type: ML",
             "Use Color AOV: True"
         ],
-        "scene": "DenoiserDOF.blend"
+        "scene": "DenoiserDOF.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_RS_DEN_052",
@@ -963,7 +978,10 @@
             "Denoiser type: ML",
             "Use Color AOV: False"
         ],
-        "scene": "DenoiserDOF.blend"
+        "scene": "DenoiserDOF.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_RS_DEN_053",
@@ -1189,7 +1207,10 @@
             "Denoiser type: ML",
             "Use Color AOV: True"
         ],
-        "scene": "DenoiserMaterials.blend"
+        "scene": "DenoiserMaterials.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_RS_DEN_067",
@@ -1206,7 +1227,10 @@
             "Denoiser type: ML",
             "Use Color AOV: False"
         ],
-        "scene": "DenoiserMaterials.blend"
+        "scene": "DenoiserMaterials.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_RS_DEN_068",
@@ -1271,7 +1295,10 @@
             "Denoiser type: ML",
             "Use Color AOV: True"
         ],
-        "scene": "DenoiserMaterials.blend"
+        "scene": "DenoiserMaterials.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_RS_DEN_072",
@@ -1291,7 +1318,10 @@
             "Denoiser type: ML",
             "Use Color AOV: False"
         ],
-        "scene": "DenoiserMaterials.blend"
+        "scene": "DenoiserMaterials.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_RS_DEN_073",
@@ -1365,7 +1395,10 @@
             "Denoiser type: ML",
             "Use Color AOV: True"
         ],
-        "scene": "DenoiserMaterials.blend"
+        "scene": "DenoiserMaterials.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_RS_DEN_077",
@@ -1385,7 +1418,10 @@
             "Denoiser type: ML",
             "Use Color AOV: False"
         ],
-        "scene": "DenoiserMaterials.blend"
+        "scene": "DenoiserMaterials.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_RS_DEN_078",
@@ -1459,7 +1495,10 @@
             "Denoiser type: ML",
             "Use Color AOV: True"
         ],
-        "scene": "DenoiserMaterials.blend"
+        "scene": "DenoiserMaterials.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_RS_DEN_082",
@@ -1479,7 +1518,10 @@
             "Denoiser type: ML",
             "Use Color AOV: False"
         ],
-        "scene": "DenoiserMaterials.blend"
+        "scene": "DenoiserMaterials.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_RS_DEN_083",
@@ -1553,7 +1595,10 @@
             "Denoiser type: ML",
             "Use Color AOV: True"
         ],
-        "scene": "DenoiserMaterials.blend"
+        "scene": "DenoiserMaterials.blend",
+        "skip_on": [
+            ["AMD Radeon VII"], ["AMD Radeon RX Vega 56 (Metal)"]
+        ]
     },
     {
         "case": "BL28_RS_DEN_087",
@@ -1573,7 +1618,10 @@
             "Denoiser type: ML",
             "Use Color AOV: False"
         ],
-        "scene": "DenoiserMaterials.blend"
+        "scene": "DenoiserMaterials.blend",
+        "skip_on": [
+            ["AMD Radeon VII"]
+        ]
     },
     {
         "case": "BL28_RS_DEN_088",

--- a/jobs/Tests/Denoiser/test_cases.json
+++ b/jobs/Tests/Denoiser/test_cases.json
@@ -960,7 +960,7 @@
         ],
         "scene": "DenoiserDOF.blend",
         "skip_on": [
-            ["AMD Radeon VII"]
+            ["AMD Radeon VII"], ["AMD Radeon RX Vega 56 (Metal)"]
         ]
     },
     {


### PR DESCRIPTION
https://rpr.cis.luxoft.com/view/RPR%20Plugins/job/RadeonProRenderBlender2.8PluginManual/1599/Test_20Report/
Skipped due to horrible artifacts on broken ML, the 2 failed cases fail randomly and were skipped after the run aswell