### PR TITLE
Fix manual launch

### DIFF
--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -7,7 +7,7 @@ set RY=%5
 set SPU=%6
 set ITER=%7
 set THRESHOLD=%8
-set ENGINE="%9"
+set ENGINE=%9
 shift
 set TOOL=%9
 


### PR DESCRIPTION
- PURPOSE
Fix manual launch of autotests. Currently, I'm getting error:
TypeError: bpy_struct: item.attr = val: enum "" not found in ('FULL', 'HIGH', 'MEDIUM', 'LOW', 'FULL2')
When trying to run any group

- REPORTS
https://rpr.cis.luxoft.com/view/RPR%20Plugins/job/RadeonProRenderBlender2.8PluginManual/2320/Test_20Report/ (NorthStar run)