### PR TITLE
Delete depedence on test group in building of path to baselines

### DIFF
--- a/jobs/Scripts/simpleRender.py
+++ b/jobs/Scripts/simpleRender.py
@@ -133,13 +133,13 @@ def main(args):
     system_pl = platform.system()
 
     baseline_dir = 'rpr_blender_autotests_baselines'
-    if args.engine == 'FULL2' and not 'NorthStar' in args.testType:
+    if args.engine == 'FULL2':
         baseline_dir = baseline_dir + '-NorthStar'
-    elif args.engine == 'LOW' and not 'Hybrid' in args.testType:
+    elif args.engine == 'LOW':
         baseline_dir = baseline_dir + '-HybridLow'
-    elif args.engine == 'MEDIUM' and not 'Hybrid' in args.testType:
+    elif args.engine == 'MEDIUM':
         baseline_dir = baseline_dir + '-HybridMedium'
-    elif args.engine == 'HIGH' and not 'Hybrid' in args.testType:
+    elif args.engine == 'HIGH':
         baseline_dir = baseline_dir + '-HybridHigh'
 
     if system_pl == "Windows":


### PR DESCRIPTION
### Jira Ticket
* https://adc.luxoft.com/jira/browse/STVCIS-1625
### Purpose
* Delete depedence on test group in building of path to baselines
### Effect of change
* Make logic of building of path to baselines in pipelines and simpleRender scripts same (make it depended only on engine name)
### :octocat: Related PR'S
* jobs_test_maya: https://github.com/luxteam/jobs_test_maya/pull/187
### Jenkins Builds
* https://rpr.cis.luxoft.com/job/RadeonProRenderMayaPluginManual/3778/