### PR TITLE
Move to blender 2.90

### DIFF
--- a/jobs/Scripts/simpleRender.py
+++ b/jobs/Scripts/simpleRender.py
@@ -48,18 +48,18 @@ def createArgsParser():
     return parser
 
 
-def athena_disable(disable):
+def athena_disable(disable, tool):
     if (platform.system() == 'Windows'):
         CONFIG_PATH = os.path.expandvars(
-            '%appdata%/Blender Foundation/Blender/2.83/scripts/addons/rprblender/config.py')
+            '%appdata%/Blender Foundation/Blender/{}/scripts/addons/rprblender/config.py'.format(tool))
         ATHENA_DIR = os.path.expandvars('%appdata%/../Local/Temp/rprblender/')
     elif (platform.system() == 'Darwin'):
         CONFIG_PATH = os.path.expanduser(
-            '~/Library/Application Support/Blender/2.83/scripts/addons/rprblender/config.py')
+            '~/Library/Application Support/Blender/{}/scripts/addons/rprblender/config.py'.format(tool))
         ATHENA_DIR = os.environ['TMPDIR'] + 'rprblender/'
     else:
         CONFIG_PATH = os.path.expanduser(
-            '~/.config/blender/2.83/scripts/addons/rprblender/config.py')
+            '~/.config/blender/{}/scripts/addons/rprblender/config.py'.format(tool))
         ATHENA_DIR = '/tmp/rprblender/'
 
     config_file_new = ''
@@ -76,9 +76,9 @@ def main(args):
     perf_count.event_record(args.output, 'Prepare tests', True)
 
     if args.testType in ['Athena']:
-        ATHENA_DIR = athena_disable(False)
+        ATHENA_DIR = athena_disable(False, args.tool)
     else:
-        ATHENA_DIR = athena_disable(True)
+        ATHENA_DIR = athena_disable(True, args.tool)
 
     core_config.main_logger.info('Make "base_functions.py"')
 

--- a/scripts/build_rpr_cache.bat
+++ b/scripts/build_rpr_cache.bat
@@ -1,5 +1,5 @@
 set TOOL_VERSION=%1
-if not defined TOOL_VERSION set TOOL_VERSION=2.83
+if not defined TOOL_VERSION set TOOL_VERSION=2.90
 
 echo import os >> cache_build.py
 echo import bpy >> cache_build.py

--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -21,7 +21,7 @@ if not defined SPU set SPU=25
 if not defined ITER set ITER=50
 if not defined THRESHOLD set THRESHOLD=0.05
 if not defined ENGINE set ENGINE="FULL"
-if not defined TOOL set TOOL=2.83
+if not defined TOOL set TOOL=2.90
 if not defined RETRIES set RETRIES=2
 if not defined UPDATE_REFS set UPDATE_REFS="No"
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -8,7 +8,7 @@ SPU=${6:-25}
 ITER=${7:-50}
 THRESHOLD=${8:-0.05}
 ENGINE=${9:-FULL}
-TOOL=${10:-2.83}
+TOOL=${10:-2.90}
 RETRIES=${11:-2}
 UPDATE_REFS=${12:-No}
 python -m pip install -r ../jobs_launcher/install/requirements.txt


### PR DESCRIPTION
- PURPOSE
Move testing to latest Blender version

- NOTES FOR REVIEWERS
Fails in attached report are not due to Blender version

- RELATED PR'S
https://github.com/luxteam/rpr_pipelines/pull/322

- REPORTS
https://rpr.cis.luxoft.com/view/RPR%20Plugins/job/RadeonProRenderBlender2.8PluginManual/2803/Test_20Report/