### PR TITLE
Marking expected black images for RPRBlenderPlugin

### DIFF
--- a/jobs/Tests/AOV/test_cases.json
+++ b/jobs/Tests/AOV/test_cases.json
@@ -414,6 +414,7 @@
             "if os.path.exists(aov_image): os.rename(aov_image, test_case_image)"
         ],
         "script_info": [
+            "Black image expected",
             "AOV: Velocity"
         ],
         "scene": "AOV_test_velocity.blend",
@@ -516,6 +517,7 @@
             "if os.path.exists(aov_image): os.rename(aov_image, test_case_image)"
         ],
         "script_info": [
+            "Black image expected",
             "AOV: Ambient Occlusion"
         ],
         "scene": "AOV_test.blend",
@@ -686,6 +688,7 @@
             "if os.path.exists(aov_image): os.rename(aov_image, test_case_image)"
         ],
         "script_info": [
+            "Black image expected",
             "AOV: Refraction"
         ],
         "scene": "AOV_test.blend",
@@ -720,6 +723,7 @@
             "if os.path.exists(aov_image): os.rename(aov_image, test_case_image)"
         ],
         "script_info": [
+            "Black image expected",
             "AOV: Volume"
         ],
         "scene": "AOV_test.blend",
@@ -791,6 +795,7 @@
             "if os.path.exists(aov_image): os.rename(aov_image, test_case_image)"
         ],
         "script_info": [
+            "Black image expected",
             "AOV: Light Group 1"
         ],
         "scene": "AOV_test.blend",
@@ -828,6 +833,7 @@
             "if os.path.exists(aov_image): os.rename(aov_image, test_case_image)"
         ],
         "script_info": [
+            "Black image expected",
             "AOV: Light group 2"
         ],
         "scene": "AOV_test.blend",
@@ -865,6 +871,7 @@
             "if os.path.exists(aov_image): os.rename(aov_image, test_case_image)"
         ],
         "script_info": [
+            "Black image expected",
             "AOV: Light group 3"
         ],
         "scene": "AOV_test.blend",
@@ -902,6 +909,7 @@
             "if os.path.exists(aov_image): os.rename(aov_image, test_case_image)"
         ],
         "script_info": [
+            "Black image expected",
             "AOV: Light group 4"
         ],
         "scene": "AOV_test.blend",
@@ -936,6 +944,7 @@
             "if os.path.exists(aov_image): os.rename(aov_image, test_case_image)"
         ],
         "script_info": [
+            "Black image expected",
             "AOV: Color Variance"
         ],
         "scene": "AOV_test.blend",

--- a/jobs/Tests/Physical_Lights/test_cases.json
+++ b/jobs/Tests/Physical_Lights/test_cases.json
@@ -875,6 +875,7 @@
         "case": "BL28_L_PL_075",
         "status": "active",
         "script_info": [
+            "Black image expected",
             "Area light, int = 0, Deactivate Intencity Normalization"
         ],
         "scene": "Physical_Lights.blend",
@@ -1091,6 +1092,7 @@
         "case": "BL28_L_PL_093",
         "status": "active",
         "script_info": [
+            "Black image expected",
             "Area light, Units Luminance, int = 100"
         ],
         "scene": "Physical_Lights.blend",
@@ -1121,6 +1123,7 @@
         "case": "BL28_L_PL_096",
         "status": "active",
         "script_info": [
+            "Black image expected",
             "Area light, Rectangle, int = 100, Size X - 0, Size Y - 0"
         ],
         "scene": "Physical_Lights.blend",
@@ -1353,6 +1356,7 @@
         "case": "BL28_L_PL_109",
         "status": "active",
         "script_info": [
+            "Black image expected",
             "Area light, Square, int = 100, Size - 0"
         ],
         "scene": "Physical_Lights.blend",
@@ -1573,6 +1577,7 @@
         "case": "BL28_L_PL_122",
         "status": "active",
         "script_info": [
+            "Black image expected",
             "Area light, Disc, int = 100, Size - 0"
         ],
         "scene": "Physical_Lights.blend",
@@ -1793,6 +1798,7 @@
         "case": "BL28_L_PL_135",
         "status": "active",
         "script_info": [
+            "Black image expected",
             "Area light, Ellipse, int = 100, Size X - 0, Size Y - 0"
         ],
         "scene": "Physical_Lights.blend",


### PR DESCRIPTION
TRELLO TICKET
https://trello.com/c/wI7AmJV9/140-marking-expected-black-images

PURPOSE
To mark all expected black images for RPRBlenderPlugin