### PR TITLE
Write logs parallel with render

### DIFF
--- a/jobs/Scripts/simpleRender.py
+++ b/jobs/Scripts/simpleRender.py
@@ -274,7 +274,7 @@ def main(args):
 
     while rc is None:
         with open(os.path.join(args.output, "renderTool.log"), 'a', encoding='utf-8') as file:
-            timeout=180
+            timeout=420
             start_time = datetime.now()
             while (datetime.now() - start_time).total_seconds() <= timeout:
                 stdout = p.stdout.readline()


### PR DESCRIPTION
### Jira Tickets
* https://adc.luxoft.com/jira/browse/STVCIS-1703
* https://adc.luxoft.com/jira/browse/STVCIS-1747
### Purpose
* Write logs parallel with render
### Effect of change
* Write logs parallel with render (it allows logs appear after timeout)
* Check that Blender didn't get stuck
### Jenkins Builds
* https://rpr.cis.luxoft.com/job/DevRadeonProRenderBlender2.8PluginManual/329/Test_20Report/
* https://rpr.cis.luxoft.com/job/DevRadeonProRenderBlender2.8PluginManual/338/Test_20Report/