### PR TITLE
Marked black image expected after weekly builds

### DIFF
--- a/jobs/Tests/AOV/test_cases.json
+++ b/jobs/Tests/AOV/test_cases.json
@@ -119,6 +119,7 @@
             "if os.path.exists(aov_image): os.rename(aov_image, test_case_image)"
         ],
         "script_info": [
+            "Black image expected",
             "AOV: Object Index"
         ],
         "scene": "AOV_test.blend"


### PR DESCRIPTION
PURPOSE
To mark all expected black images after weekly build

REPORTS
https://rpr.cis.luxoft.com/job/RadeonProRenderBlender2.8Plugin-WeeklyFullNorthstar/13/Test_20Report/