### PR TITLE
increased timeouts for failed groups, PL_012 skip

### DIFF
--- a/jobs/Tests/Adaptive_Sampling/test.job-manifest.xml
+++ b/jobs/Tests/Adaptive_Sampling/test.job-manifest.xml
@@ -3,7 +3,7 @@
 
     <outpath value="{OutputDir}"/>
 
-    <execute command='python "{ResourcesDir}/simpleRender.py"' timeout="1200">
+    <execute command='python "{ResourcesDir}/simpleRender.py"' timeout="2400">
         <argument>--tool "{Tool}"</argument>
         <argument>--render_device "{RenderDevice}"</argument>
         <argument>--output "{OutputDir}"</argument>

--- a/jobs/Tests/Image_Formats/test.job-manifest.xml
+++ b/jobs/Tests/Image_Formats/test.job-manifest.xml
@@ -3,7 +3,7 @@
 
     <outpath value="{OutputDir}"/>
 
-    <execute command='python "{ResourcesDir}/simpleRender.py"' timeout="600">
+    <execute command='python "{ResourcesDir}/simpleRender.py"' timeout="1200">
         <argument>--tool "{Tool}"</argument>
         <argument>--render_device "{RenderDevice}"</argument>
         <argument>--output "{OutputDir}"</argument>

--- a/jobs/Tests/Physical_Lights/test_cases.json
+++ b/jobs/Tests/Physical_Lights/test_cases.json
@@ -125,7 +125,7 @@
     },
     {
         "case": "BL28_L_PL_012",
-        "status": "active",
+        "status": "skipped",
         "script_info": [
             "Point light with TIFF, int = 100"
         ],

--- a/jobs/Tests/Render_Layer/test.job-manifest.xml
+++ b/jobs/Tests/Render_Layer/test.job-manifest.xml
@@ -3,7 +3,7 @@
 
     <outpath value="{OutputDir}"/>
 
-    <execute command='python "{ResourcesDir}/simpleRender.py"' timeout="900">
+    <execute command='python "{ResourcesDir}/simpleRender.py"' timeout="1800">
         <argument>--tool "{Tool}"</argument>
         <argument>--render_device "{RenderDevice}"</argument>
         <argument>--output "{OutputDir}"</argument>


### PR DESCRIPTION
Purpose:
To increase timeouts for failed groups in build given, skipped BL28_L_PL_012

Build:
https://rpr.cis.luxoft.com/job/RadeonProRenderBlender2.8PluginManual/3239/Test_20Report/